### PR TITLE
add round index to track which hint player got in each round

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -114,6 +114,7 @@ Empirica.gameInit((game) => {
     const task = tasks[i];
     task.instructions = instructions[task.task];
     round.set("task", task);
+    round.set("index", i);
 
     for (let i = 0; i < nInteractions + 1; i++) {
       round.addStage({

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,2 @@
+SET MONGO_URL=mongodb+srv://joshua:dataforthew1n@empirica-sandbox.bxpfk.mongodb.net/info_diversity_test_sam
+meteor --settings settings.json


### PR DESCRIPTION
When merging the new master to the info_diversity I notice that the `round.set("index", i);` in the `server/main.js` was no longer there. This allows experiments to track which hints players got on each round. This is useful if you are using a wildcard and want to be able to compare participant results according to the hints received.

I restored it to the info_diversity, so I thought I would also propose it for the master.