### PR TITLE
restore round index to track which hint was given to the player

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -114,6 +114,7 @@ Empirica.gameInit((game) => {
     const task = tasks[i];
     task.instructions = instructions[task.task];
     round.set("task", task);
+    round.set("index", i);
 
     for (let i = 0; i < nInteractions + 1; i++) {
       round.addStage({


### PR DESCRIPTION
When merging the new master to the info_diversity I notice that the round.set("index", i); in the server/main.js was no longer there. This allows experiments to track which hints players got on each round. This is useful if you are using a wildcard and want to be able to compare participant results according to the hints received.

I restored it to the info_diversity, so I thought I would also propose it for the master.