### PR TITLE
added prevent pluralize feature to tasks

### DIFF
--- a/client/components/round/ResponseInput.jsx
+++ b/client/components/round/ResponseInput.jsx
@@ -112,6 +112,7 @@ export default class ResponseInput extends React.Component {
             magnitude
             focused={focused}
             answer={answer}
+            preventPluralize={task.question.preventPluralize}
             {...this.props}
           />
           <NumberToWords answer={answer} task={task} {...this.props} />
@@ -146,26 +147,26 @@ export default class ResponseInput extends React.Component {
         {answer === "" ? (
           ""
         ) : (
-          <>
-            <div className="mt-12">
-              <Button
-                tick
-                text={player.stage.submitted ? "Submitted" : "Submit"}
-                done={player.stage.submitted}
-                disabled={
-                  player.stage.submitted ||
-                  answer < minmax.min ||
-                  answer > minmax.max
-                }
-              />
-            </div>
-            {interactionMode === "continuous" && stage.name === "social" && (
-              <div className="text-gray-400 text-xs mt-3">
-                <i>You can edit your previous answer.</i>
+            <>
+              <div className="mt-12">
+                <Button
+                  tick
+                  text={player.stage.submitted ? "Submitted" : "Submit"}
+                  done={player.stage.submitted}
+                  disabled={
+                    player.stage.submitted ||
+                    answer < minmax.min ||
+                    answer > minmax.max
+                  }
+                />
               </div>
-            )}
-          </>
-        )}
+              {interactionMode === "continuous" && stage.name === "social" && (
+                <div className="text-gray-400 text-xs mt-3">
+                  <i>You can edit your previous answer.</i>
+                </div>
+              )}
+            </>
+          )}
       </form>
     );
   }

--- a/client/components/round/Unit.jsx
+++ b/client/components/round/Unit.jsx
@@ -3,20 +3,18 @@ import { getUnit } from "../../../shared/unit";
 
 export default class Unit extends React.Component {
   render() {
-    const { input, result, magnitude, round, focused, answer } = this.props;
-    const unit = getUnit({ round, answer, magnitude });
+    const { input, result, magnitude, round, focused, answer, preventPluralize } = this.props;
+    const unit = getUnit({ round, answer, magnitude, preventPluralize });
 
     return (
       <div
         className={
           result || input
-            ? `pl-2 py-2 lg:text-xl xl:text-2xl text-md ${
-                input
-                  ? "border-b-2 border-gray-300 text-gray-400"
-                  : "text-gray-500 pr-2"
-              } whitespace-nowrap leading-snug ${
-                focused ? "border-gray-500" : "border-gray-300"
-              }`
+            ? `pl-2 py-2 lg:text-xl xl:text-2xl text-md ${input
+              ? "border-b-2 border-gray-300 text-gray-400"
+              : "text-gray-500 pr-2"
+            } whitespace-nowrap leading-snug ${focused ? "border-gray-500" : "border-gray-300"
+            }`
             : ""
         }
       >

--- a/shared/unit.js
+++ b/shared/unit.js
@@ -1,7 +1,7 @@
 import { magnitudesToEnglish } from "./conversions";
 import pluralize from "pluralize";
 
-export function getUnit({ round, answer, magnitude }) {
+export function getUnit({ round, answer, magnitude, preventPluralize }) {
   const task = round.get("task");
 
   let unit = task.question.unit;
@@ -14,6 +14,8 @@ export function getUnit({ round, answer, magnitude }) {
   }
 
   const a = parseInt(answer || 0, 10);
-  unit = pluralize(unit, a);
+  if (!preventPluralize) {
+    unit = pluralize(unit, a);
+  }
   return unit;
 }


### PR DESCRIPTION
Whilst creating tasks for our own project, I came across a problem. Some of my question units were being pluralized even though I did not want to. For example, I had a question with a unit of  `/ 10`, but as soon as I gave an answer above 1 it would transform it to `/ 10s`. I had other issues, for example with `% win probability`. 

To correct for that, I added a feature where adding `preventPluralize: true` in the `question:` object of a question will stop the pluralising function that changes the wording of the unit.

For example:
```
// prototype of sports_NBA_winprob
    {
        id: 2,
        class: "sports_forecast",
        task: "sports_NBA_winprob",

        question: {
            teamA: "Charlotte Hornets",
            teamB: "Houston Rockets",
            dateEvent: "Monday the 8th of February",
            dateHints: "Thursday the 4th of February - 6pm UK time",
            season: "2020-2021",

            min: 0,
            max: 100,
            hintName: "Additional Information",

            unit: "% win probability",
            preventPluralize: true,

            get text() {
                return "How likely (0-100%) are the " + this.teamA + " to win their game against the " + this.teamB + " on " + this.dateEvent
            },
            get description() {
                return "All the " + this.hintName + " provided was accurate as of " + this.dateHints + "."
            },
        },
    },
```

If thought this might be a feature you would want in the master.
Best wishes, 
Sam