### PR TITLE
used nullish coalescing to fix issues with 0 answer

### DIFF
--- a/client/components/round/ResponseInput.jsx
+++ b/client/components/round/ResponseInput.jsx
@@ -11,8 +11,8 @@ export default class ResponseInput extends React.Component {
 
     this.state = {
       answer:
-        props.player.stage.get("tmpanswer") ||
-        props.player.round.get("answer") ||
+        props.player.stage.get("tmpanswer") ??
+        props.player.round.get("answer") ??
         "",
       focused: false,
     };


### PR DESCRIPTION
The code did not consider 0 as an answer once one moved on from a response stage and unto another response stage or a social stage.

I believe the answer is to use **nullish coalescing**, with `??` instead of `||` when setting the `answer` state in the `ResponseInput`. 