### PR TITLE
allow clicking OK in discreet social even if no answer

### DIFF
--- a/client/components/round/ResponseInput.jsx
+++ b/client/components/round/ResponseInput.jsx
@@ -41,25 +41,34 @@ export default class ResponseInput extends React.Component {
   handleSubmit = (event) => {
     event.preventDefault();
 
-    const { player } = this.props;
-    const { answer } = this.state;
+    const { player,
+      stage,
+      game: {
+        treatment: { interactionMode },
+      }
+    } = this.props;
 
-    if (answer === "") {
-      return;
+    if (!(interactionMode === "discreet" && stage.name === "social")) {
+      const { answer } = this.state;
+
+      if (answer === "") {
+        return;
+      }
+
+      // If answered as int, save int, otherwise save float
+
+      const f = parseFloat(answer);
+      const i = parseInt(answer, 10);
+
+      let a = f;
+      if (f === i) {
+        a = i;
+      }
+
+      player.stage.set("answer", a);
+      player.round.set("answer", a);
     }
 
-    // If answered as int, save int, otherwise save float
-
-    const f = parseFloat(answer);
-    const i = parseInt(answer, 10);
-
-    let a = f;
-    if (f === i) {
-      a = i;
-    }
-
-    player.stage.set("answer", a);
-    player.round.set("answer", a);
     player.stage.submit();
   };
 
@@ -144,7 +153,7 @@ export default class ResponseInput extends React.Component {
         )}
         */}
 
-        {answer === "" ? (
+        {answer === "" && !(interactionMode === "discreet" && stage.name === "social") ? (
           ""
         ) : (
             <>


### PR DESCRIPTION
If you don't give an answer in the response stage, then you answer will be empty for the social stage, thereby, the "submit/ok" button will not appear. In the `discreet` social stages you cannot change your answer, so you cannot get the button "ok" once you have failed to answer in the response stage. Consequently, if you don't give an answer, you cannot then end the social stage, forcing everyone to end until the end.

I made changes so that the button always appear in the `discreet` social stages, and that pressing the "ok" button will skip the setting of answers for that stage, and just submit. In `discreet` social stages we do not need to reset the answer: it should be considered the same as the response stage answer because you cannot change your answer during `discreet` social stages.