### PR TITLE
fixes about social information (feedback, signal when submitted)

### DIFF
--- a/client/components/round/SocialExposure.jsx
+++ b/client/components/round/SocialExposure.jsx
@@ -9,7 +9,6 @@ export default function SocialExposure(props) {
   const {
     chat = false,
     hideSocialNumeric = false,
-    feedback = false,
     meanSocialInfo = false,
     minSocialInfo = false,
     maxSocialInfo = false,
@@ -36,10 +35,6 @@ export default function SocialExposure(props) {
     }
   });
 
-  if (stage.name === "response" || hideSocialNumeric) {
-    isFeedback = false;
-  }
-
   if (minSocialInfo) {
     info.push("min");
   }
@@ -58,39 +53,37 @@ export default function SocialExposure(props) {
 
   return (
     <div
-      className={`pr-4 h-full grid grid-rows-${feedback && showChat ? 2 : 1}`}
+      className={`pr-4 h-full grid grid-rows-${showChat ? 2 : 1}`}
     >
-      {feedback && (
-        <div className="overflow-y-auto h-full">
-          <div className="py-4 flex flex-col min-h-full justify-center">
-            {isFeedback && (
-              <>
-                {neighbors.length > 0 && info.length > 0 && (
-                  <dl>
-                    {info.map((i) => (
-                      <SocialInfo
-                        key={i}
-                        type={i}
-                        neighbors={neighbors}
-                        task={task}
-                      />
-                    ))}
-                  </dl>
-                )}
-                {neighbors.length > 0 && (
-                  <div className="mt-5">
-                    <PlayersResponse
-                      {...props}
+      <div className="overflow-y-auto h-full">
+        <div className="py-4 flex flex-col min-h-full justify-center">
+          {stage.name !== "response" && (
+            <>
+              {neighbors.length > 0 && info.length > 0 && !hideSocialNumeric && (
+                <dl>
+                  {info.map((i) => (
+                    <SocialInfo
+                      key={i}
+                      type={i}
                       neighbors={neighbors}
-                      withInfo={info.length > 0}
+                      task={task}
                     />
-                  </div>
-                )}
-              </>
-            )}
-          </div>
+                  ))}
+                </dl>
+              )}
+              {neighbors.length > 0 && (
+                <div className="mt-5">
+                  <PlayersResponse
+                    {...props}
+                    neighbors={neighbors}
+                    withInfo={info.length > 0}
+                  />
+                </div>
+              )}
+            </>
+          )}
         </div>
-      )}
+      </div>
       {showChat && <ChatContainer player={player} game={game} />}
     </div>
   );

--- a/client/game/PlayersResponse.jsx
+++ b/client/game/PlayersResponse.jsx
@@ -8,7 +8,10 @@ import { TickIcon } from "../components/icons/TickIcon";
 
 export default class PlayersResponse extends React.Component {
   render() {
-    const { player, round, neighbors: players, stage } = this.props;
+    const { player, round,
+      game: { treatment: { hideSocialNumeric, feedback } },
+      neighbors: players, stage
+    } = this.props;
 
     const allPlayers = [player, ...players];
     const task = round.get("task");
@@ -66,22 +69,23 @@ export default class PlayersResponse extends React.Component {
                     />
                   )}
 
-                  <div
-                    className={`text-sm ${
-                      minmaxerr ? "text-red-500" : "text-gray-500"
-                    }`}
-                  >
-                    <NumberFormat
-                      value={answer}
-                      displayType={"text"}
-                      thousandSeparator={true}
-                    />{" "}
-                    <span
-                      className={minmaxerr ? "text-red-400" : "text-gray-400"}
+                  {!hideSocialNumeric &&
+                    <div
+                      className={`text-sm ${minmaxerr ? "text-red-500" : "text-gray-500"
+                        }`}
                     >
-                      {unit}
-                    </span>
-                  </div>
+                      <NumberFormat
+                        value={answer}
+                        displayType={"text"}
+                        thousandSeparator={true}
+                      />{" "}
+                      <span
+                        className={minmaxerr ? "text-red-400" : "text-gray-400"}
+                      >
+                        {unit}
+                      </span>
+                    </div>
+                  }
                 </div>
 
                 {minmaxerr ? (
@@ -91,16 +95,18 @@ export default class PlayersResponse extends React.Component {
                     </div>
                   </div>
                 ) : (
-                  ""
-                )}
+                    ""
+                  )}
               </div>
 
-              <div className="text-gray-500 pl-5 text-sm flex items-center">
-                <CoinIcon />
-                <div className="pl-2">
-                  {stage.name === "feedback" ? p.round.get("score") : 0}
+              {feedback &&
+                <div className="text-gray-500 pl-5 text-sm flex items-center">
+                  <CoinIcon />
+                  <div className="pl-2">
+                    {stage.name === "feedback" ? p.round.get("score") : 0}
+                  </div>
                 </div>
-              </div>
+              }
             </div>
           );
         })}


### PR DESCRIPTION
Setting `feedback` factor to `false` would stop any social information in the social stages. I think we should be able to separate out `feedback` (having our answer compared to the true answer) and `chat` and `hideSocialNumeric` (which control whether chats and numeric information are available to the participant in the social stages, respectively). I made this separation here.

I also think the coins and 0/player score should not be shown when `feedback` factor is set to `false`. I made that change here too.

I made it so `hideSocialNumeric` no longer hides everything but only hides the actual numeric information. This means that the names of the other players in the group will still show. Allowing participants to still see when they neighbours have submitted a stage. Although this feature might be best separated out of the social feedback (with a bar just below the timer and score bar where you can see all the avatars of the other players with a tick/cross as to whether they have finished a stage or not?).