### PR TITLE
fix by returning null instead of 0 when no values or no answer

### DIFF
--- a/shared/helper.js
+++ b/shared/helper.js
@@ -47,7 +47,7 @@ export function getSocialInfoValue(type, neighbors, task) {
       const answer = p.stage.get("tmpanswer") || p.round.get("answer");
 
       if (answer === undefined) {
-        return 0;
+        return null;
       }
 
       if (task.question.min !== undefined) {
@@ -66,7 +66,7 @@ export function getSocialInfoValue(type, neighbors, task) {
     .filter((a) => a !== null);
 
   if (values.length === 0) {
-    return 0;
+    return null;
   }
 
   switch (type) {


### PR DESCRIPTION
This should fix the problem of non-responses being counted as 0s #65 in the numeric information shown during the social phase.
When there is no answer, it is returned as null instead of zero. This will then not affect the information such as min, max, mean, etc.
When there are no answers from any of the neighbours, return null as well, instead of returning a min, max, mean, etc. of 0.