### PR TITLE
fix: add separator on social value #63

### DIFF
--- a/client/components/round/SocialInfo.jsx
+++ b/client/components/round/SocialInfo.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import NumberFormat from "react-number-format";
 import { getSocialInfoValue } from "../../../shared/helper";
 
 export default function SocialInfo({ type, neighbors, task }) {
@@ -15,9 +16,16 @@ export default function SocialInfo({ type, neighbors, task }) {
             of neighbors
           </div>
         </dt>
-        <dd className="pl-5 text-lg font-semibold text-gray-900 flex items-center">
-          {socialInfoValue}
-        </dd>
+        <NumberFormat
+          thousandSeparator={true}
+          isNumericString
+          className="pl-5 text-lg font-semibold text-gray-900 flex items-center"
+          placeholder="0.0"
+          autoFocus
+          name="answer"
+          displayType="text"
+          value={socialInfoValue}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
### Fixes
- [x] Add thousand separator on social info numeric

### Context
#63 

### Screenshots
<img width="337" alt="Screen Shot 2021-04-01 at 16 02 03" src="https://user-images.githubusercontent.com/30768964/113263257-1f58d600-9304-11eb-9836-759954250003.png">
