### PR TITLE
Answers of 0 where considered as nonanswers and shown as _

### DIFF
--- a/client/components/meta/response/ResponseContainer.jsx
+++ b/client/components/meta/response/ResponseContainer.jsx
@@ -32,7 +32,7 @@ export class ResponseContainer extends Component {
     const { unit } = task.question;
     const otherPlayers = game.players.filter((p) => p._id !== player._id);
     let answer =
-      player.stage.get("tmpanswer") || player.round.get("answer") || "_";
+      player.stage.get("tmpanswer") ?? player.round.get("answer") ?? "_";
 
     return (
       <div className="response-container">


### PR DESCRIPTION
In the new alternative layout, when players enter a response of "0", their answer in the "Other players detailed" in the social phase was shown as "_" (i.e., it was considered as a nonresponse) instead of "0". Fixed this with nullish coalescing.

Edit: also fixed this for the player's own response