### PR TITLE
When there are not chats, center the elements in the social stage

### DIFF
--- a/client/components/meta/MetaContainer.jsx
+++ b/client/components/meta/MetaContainer.jsx
@@ -16,7 +16,7 @@ export class MetaContainer extends Component {
 
     return (
       <div
-        className={`meta-container ${isResponseStage ? "response-stage" : ""}`}
+        className={`meta-container ${showChat ? "with-chat" : "without-chat"} ${isResponseStage ? "response-stage" : ""}`}
       >
         {!isResponseStage && (
           <>

--- a/client/components/meta/meta.less
+++ b/client/components/meta/meta.less
@@ -2,10 +2,20 @@
   overflow: auto;
   display: grid;
   grid-template-rows: 1fr;
-  grid-template-columns: 225px 1fr 225px;
+
   grid-column-gap: 14px;
   padding: 0 20px 10px 20px;
   margin-top: 30px;
+
+  &.with-chat {
+    grid-template-columns: 225px 1fr 225px;
+  }
+
+  &.without-chat {
+    grid-template-columns: 225px 1px 225px;
+    justify-content: center;
+  }
+
 
   &.response-stage {
     grid-template-columns: 50%;


### PR DESCRIPTION
Instead of having a big gap where the chats were, I centred the elements of the social stage grid when there are not chats.